### PR TITLE
Implicit using enable

### DIFF
--- a/games/Asteroids/Asteroids.csproj
+++ b/games/Asteroids/Asteroids.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp7.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/games/Asteroids/Level.cs
+++ b/games/Asteroids/Level.cs
@@ -21,6 +21,7 @@ public abstract class Level
         _wHeight = _gameWindow.Height;
         _wWidth = _gameWindow.Width;
         lvlComplete = new Bitmap("levelComplete","Lvlcomplete.png");
+        
     }
 
     public virtual void Draw()
@@ -121,13 +122,13 @@ public abstract class Level
 
 public class Level1: Level
 {
-    private Timer _lvlTimer;
+    private SplashKitSDK.Timer _lvlTimer;
     private Font _GameFont;
     
 
     public Level1(Window GameWindow,Game game): base(GameWindow,game )
     {
-        _lvlTimer = new Timer("lvl1Timer");
+        _lvlTimer = new SplashKitSDK.Timer("lvl1Timer");
         _lvlTimer.Start();
         _GameFont = new Font("pricedown_bl", "fonts/pricedown_bl.otf");
 

--- a/games/Asteroids/Menu.cs
+++ b/games/Asteroids/Menu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using SplashKitSDK;
 
 // 

--- a/games/Asteroids/Player.cs
+++ b/games/Asteroids/Player.cs
@@ -13,7 +13,7 @@ public class Player
     private string _Player;
     private List<Shooting> _KillShots = new List<Shooting>();
     public bool IsDead { get; private set; }
-    private Timer _InvulnerableTime;
+    private SplashKitSDK.Timer _InvulnerableTime;
     private bool _IsInvulnerable;
 
     public string Name { get { return _Player; } }
@@ -26,7 +26,7 @@ public class Player
         _Player = Player;
         _shots = new List<Shooting>();
         IsDead = false;
-        _InvulnerableTime = new Timer($"{Player} Invulnerable");
+        _InvulnerableTime = new SplashKitSDK.Timer($"{Player} Invulnerable");
         _InvulnerableTime.Start();
         _IsInvulnerable = true;
         if (PlayersNo == 1)

--- a/games/Asteroids/Score.cs
+++ b/games/Asteroids/Score.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 public abstract class Score
 {
 
-    protected Timer _ScoreTimer;
+    protected SplashKitSDK.Timer _ScoreTimer;
     //protected List<Bitmap> _LivesBitmap = new List<Bitmap>();
     protected Bitmap _LivesBitmap;
     protected Window _GameWindow;
@@ -26,7 +26,7 @@ public abstract class Score
         {
             _LivesBitmap.Add(new Bitmap($"Lives {i}", "images/heart.png"));          
         } */
-        _ScoreTimer = new Timer($"{player} Timer");
+        _ScoreTimer = new SplashKitSDK.Timer($"{player} Timer");
         _LivesBitmap = new Bitmap($"Lives", "heart.png");        
         _GameWindow = gameWindow;
         _ScoreTimer.Start();


### PR DESCRIPTION
Changed implicit using field to enable in Asteroids.csproj

Necessary for using LinkedList functions for some reason, as "using System.Collections.Generic;" does not have the same function list, some of which I was using.
methods "First()" and "ElementAt()" no longer existed and would not compile
First could be worked around, but ElementAt would need replacement code.

Enabling implicit using, required me to fix ambiguous timer declarations in Level.cs, Player.cs, Score.cs as System has it's own timer as well.

Also commented out the test sprite draw function, though experimental code still exists.